### PR TITLE
feat(db): 時間割に必要なテーブルを作成

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -12,11 +12,8 @@ CREATE TABLE `Lectures` (
 
 CREATE TABLE `Timetables` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '時間割ID',
-  `lecture_id` int NOT NULL COMMENT '講義ID',
-  `classroom` varchar(64) DEFAULT NULL COMMENT '教室',
-  `day_of_week` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '開講曜日',
-  `period` int NOT NULL COMMENT '開講時限',
-  `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',
+  `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '時間割名',
+  `memo` varchar(100) DEFAULT NULL COMMENT 'メモ',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割情報';
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,6 +1,6 @@
--- syllabus.Lectures definition
+-- syllabus.lectures definition
 
-CREATE TABLE `Lectures` (
+CREATE TABLE `lectures` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '講義ID',
   `name` varchar(96) NOT NULL COMMENT '講義名',
   `teacher` varchar(32) DEFAULT NULL COMMENT '教員名',
@@ -8,9 +8,9 @@ CREATE TABLE `Lectures` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
 
 
--- syllabus.Timetables definition
+-- syllabus.timetables definition
 
-CREATE TABLE `Timetables` (
+CREATE TABLE `timetables` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '時間割ID',
   `name` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '時間割名',
   `memo` varchar(100) DEFAULT NULL COMMENT 'メモ',

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -8,22 +8,12 @@ CREATE TABLE `Lectures` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
 
 
--- syllabus.Classrooms definition
-
-CREATE TABLE `Classrooms` (
-  `id` int NOT NULL AUTO_INCREMENT COMMENT '教室ID',
-  `campus_id` int NOT NULL COMMENT 'キャンパス',
-  `name` varchar(100) NOT NULL COMMENT '教室名',
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='教室情報';
-
-
 -- syllabus.Timetables definition
 
 CREATE TABLE `Timetables` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '時間割ID',
   `lecture_id` int NOT NULL COMMENT '講義ID',
-  `classroom_id` int DEFAULT NULL COMMENT '教室ID',
+  `classroom` varchar(64) DEFAULT NULL COMMENT '教室',
   `day_of_week` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '開講曜日',
   `period` int NOT NULL COMMENT '開講時限',
   `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE `Lectures` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '講義ID',
   `name` varchar(96) NOT NULL COMMENT '講義名',
   `teacher` varchar(32) DEFAULT NULL COMMENT '教員名',
-  PRIMARY KEY (`id`),
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
 
 
@@ -17,5 +17,5 @@ CREATE TABLE `Timetables` (
   `day_of_week` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '開講曜日',
   `period` int NOT NULL COMMENT '開講時限',
   `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',
-  PRIMARY KEY (`id`),
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割情報';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -3,7 +3,7 @@
 CREATE TABLE `Lectures` (
   `id` int NOT NULL AUTO_INCREMENT COMMENT '講義ID',
   `name` varchar(96) NOT NULL COMMENT '講義名',
-  `place_id` int DEFAULT NULL COMMENT '教室',
+  `teacher` varchar(32) DEFAULT NULL COMMENT '教員名',
   PRIMARY KEY (`id`),
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -21,9 +21,11 @@ CREATE TABLE `timetables` (
 -- syllabus.timetable_lecture definition
 
 CREATE TABLE `timetable_lecture` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '関連付けID',
   `timetable_id` int NOT NULL COMMENT '時間割ID',
   `lecture_id` int NOT NULL COMMENT '講義ID',
   `classroom` varchar(64) DEFAULT NULL COMMENT '教室',
   `day_of_week` varchar(4) NOT NULL COMMENT '開講曜日',
-  `period` int NOT NULL COMMENT '開講時限'
+  `period` int NOT NULL COMMENT '開講時限',
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割と講義を紐づける中間テーブル';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,37 @@
+-- syllabus.Lectures definition
+
+CREATE TABLE `Lectures` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '講義ID',
+  `name` varchar(96) NOT NULL COMMENT '講義名',
+  `place_id` int DEFAULT NULL COMMENT '教室',
+  PRIMARY KEY (`id`),
+  KEY `Lectures_FK` (`place_id`),
+  CONSTRAINT `Lectures_FK` FOREIGN KEY (`place_id`) REFERENCES `Classrooms` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
+
+
+-- syllabus.Classrooms definition
+
+CREATE TABLE `Classrooms` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '教室ID',
+  `campus_id` int NOT NULL COMMENT 'キャンパス',
+  `name` varchar(100) NOT NULL COMMENT '教室名',
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='教室情報';
+
+
+-- syllabus.Timetables definition
+
+CREATE TABLE `Timetables` (
+  `id` int NOT NULL AUTO_INCREMENT COMMENT '時間割ID',
+  `lecture_id` int NOT NULL COMMENT '講義ID',
+  `classroom_id` int DEFAULT NULL COMMENT '教室ID',
+  `day_of_week` varchar(4) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL COMMENT '開講曜日',
+  `period` int NOT NULL COMMENT '開講時限',
+  `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',
+  PRIMARY KEY (`id`),
+  KEY `Timetables_FK` (`lecture_id`),
+  KEY `Timetables_FK_1` (`classroom_id`),
+  CONSTRAINT `Timetables_FK` FOREIGN KEY (`lecture_id`) REFERENCES `Lectures` (`id`),
+  CONSTRAINT `Timetables_FK_1` FOREIGN KEY (`classroom_id`) REFERENCES `Classrooms` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割情報';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -5,8 +5,6 @@ CREATE TABLE `Lectures` (
   `name` varchar(96) NOT NULL COMMENT '講義名',
   `place_id` int DEFAULT NULL COMMENT '教室',
   PRIMARY KEY (`id`),
-  KEY `Lectures_FK` (`place_id`),
-  CONSTRAINT `Lectures_FK` FOREIGN KEY (`place_id`) REFERENCES `Classrooms` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='講義情報';
 
 
@@ -30,8 +28,4 @@ CREATE TABLE `Timetables` (
   `period` int NOT NULL COMMENT '開講時限',
   `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',
   PRIMARY KEY (`id`),
-  KEY `Timetables_FK` (`lecture_id`),
-  KEY `Timetables_FK_1` (`classroom_id`),
-  CONSTRAINT `Timetables_FK` FOREIGN KEY (`lecture_id`) REFERENCES `Lectures` (`id`),
-  CONSTRAINT `Timetables_FK_1` FOREIGN KEY (`classroom_id`) REFERENCES `Classrooms` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割情報';

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -19,3 +19,14 @@ CREATE TABLE `Timetables` (
   `memo` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci DEFAULT NULL COMMENT 'メモ',
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割情報';
+
+
+-- syllabus.timetable_lecture definition
+
+CREATE TABLE `timetable_lecture` (
+  `timetable_id` int NOT NULL COMMENT '時間割ID',
+  `lecture_id` int NOT NULL COMMENT '講義ID',
+  `classroom` varchar(64) DEFAULT NULL COMMENT '教室',
+  `day_of_week` varchar(4) NOT NULL COMMENT '開講曜日',
+  `period` int NOT NULL COMMENT '開講時限'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='時間割と講義を紐づける中間テーブル';


### PR DESCRIPTION
### 概要
時間割を登録するのに必要な情報を格納するテーブルを作成します。

### 関連するissue
closes #4 

### 機能詳細
- [x] 時間割テーブルを追加します。
- [x] 講義テーブルを追加します。
 
### 備考
PlanetScale(本番で使う予定のDBaaS)では外部キー制約をつけられないので、とりあえず教室情報はフロント側で管理する方向でいきます
